### PR TITLE
Prefer previewImage

### DIFF
--- a/src/includes/template.pug
+++ b/src/includes/template.pug
@@ -4,7 +4,7 @@ block vars
   - const pageTitle = title && title != siteData.meta.title ? `${title} · ${siteData.meta.title}` : `${siteData.meta.title} · ${siteData.meta.tagline}`
   - const pageDescription = description || siteData.meta.description
   - const pageKeywords = keywords || siteData.meta.keywords
-  - const pageCard = cardImage || teaser || siteData.meta.cardImage
+  - const pageCard = previewImage || cardImage || teaser || siteData.meta.cardImage
   - const themeColor = siteData.meta.themeColor
 
 <!DOCTYPE html>


### PR DESCRIPTION
Instead of this image when sharing:
<img width="732" alt="image" src="https://github.com/Peach2Peach/public-website/assets/42438775/45741947-85f8-496a-8db0-0ee7a1632645">

We can use the preview image:
<img width="694" alt="image" src="https://github.com/Peach2Peach/public-website/assets/42438775/4c6aeeb2-61af-4845-b627-523fde549fdd">