### PR TITLE
seo: fix og:image localhost bug, simplify homepage redirect

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,10 +1,12 @@
 const IS_DEV = process.env.NODE_ENV === 'development'
+const CANONICAL_URL = 'https://peachbitcoin.com'
 const HOST = IS_DEV ? 'http://localhost:3000' : getBaseUrl()
 
 function getBaseUrl() {
   const { DEPLOY_PRIME_URL, URL } = process.env
   const branchUrl = DEPLOY_PRIME_URL || URL || ''
-  return !branchUrl.match('master--') ? branchUrl : 'https://peachbitcoin.com'
+  if (!branchUrl || branchUrl.match('master--')) return CANONICAL_URL
+  return branchUrl
 }
 
 function getUrl(url, lang) {

--- a/src/index.pug
+++ b/src/index.pug
@@ -112,22 +112,13 @@ block teaser
 
   script.
     document.addEventListener('DOMContentLoaded', function() {
-      let userLocale = navigator.language || navigator.userLanguage;
-      const supportedLocales = ['es', 'de', 'it', 'fr', 'pt'];
-      let pathLocale = userLocale.split('-')[0];
-
-      let currentPath = window.location.pathname;
-      let redirected = sessionStorage.getItem('redirected'); // Check if redirected before
-
-      if (!redirected) { // If not redirected before
-        if (currentPath === '/') {
-          if (pathLocale === 'en') {
-            window.location.pathname = '/index.html'; // routing to english
-          } else if (supportedLocales.includes(pathLocale)) {
-            window.location.pathname = '/' + pathLocale; // Redirect to the right language always if supported
-          }
-          sessionStorage.setItem('redirected', 'true'); // Set redirected in sessionstorage / die at every session
-        }
+      if (window.location.pathname !== '/') return;
+      if (sessionStorage.getItem('redirected')) return;
+      var supportedLocales = ['es', 'de', 'it', 'fr', 'pt'];
+      var browserLang = (navigator.language || navigator.userLanguage || '').split('-')[0];
+      sessionStorage.setItem('redirected', 'true');
+      if (supportedLocales.includes(browserLang)) {
+        window.location.replace('/' + browserLang + '/');
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes two SEO bugs blocking proper indexation and social previews for peachbitcoin.com.

- **`helpers.js`** — `getBaseUrl()` returned an empty string when no Netlify env vars were set, and `HOST` fell back to `http://localhost:3000` in dev mode. Production `og:image` / `twitter:image` were rendering as `http://localhost:3000/img/card.jpg` (or as broken relative URLs depending on env). Now `getBaseUrl()` falls back to `https://peachbitcoin.com` whenever the build environment can't supply a real branch URL, so prod builds always emit absolute social-preview URLs.
- **`src/index.pug`** — Removed the broken `/` → `/index.html` redirect that fired for English browsers (creating a duplicate URL inconsistent with the canonical `<link>`). Kept a simplified locale UX redirect for `es` / `de` / `it` / `fr` / `pt` browsers landing on `/`.

Verified locally with `npm run prod`:
- `og:image` content: `http://peachbitcoin.com/img/card-<hash>.jpg` ✓
- `og:image:secure_url` and `twitter:image`: `https://peachbitcoin.com/img/card-<hash>.jpg` ✓
- Zero `localhost:3000` references in `dist/` ✓
- `dist/sitemap.xml` regenerated with 936 URLs across all 6 languages ✓

## Test plan

- [ ] Netlify deploy preview builds successfully and the preview's `<head>` shows absolute `og:image` URLs (no `localhost`)
- [ ] After merge to `main` and prod deploy, `https://peachbitcoin.com/sitemap.xml` returns 200 and lists ~936 URLs
- [ ] Run https://peachbitcoin.com through the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) — confirm card image renders
- [ ] Spot-check English homepage: visiting `/` no longer redirects to `/index.html`
- [ ] Spot-check non-English browser: visiting `/` with browser locale set to `de` still redirects to `/de/`
- [ ] After deploy, submit `/sitemap.xml` to Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)